### PR TITLE
module: add :ui good-scroll

### DIFF
--- a/modules/ui/pixel-scroll/README.org
+++ b/modules/ui/pixel-scroll/README.org
@@ -1,0 +1,18 @@
+#+TITLE:   ui/pixel-scroll
+#+DATE:    December 11, 2021
+#+SINCE:   v3.0
+#+STARTUP: inlineimages
+
+* Table of Contents :TOC_3:noexport:
+- [[#description][Description]]
+  - [[#module-flags][Module Flags]]
+  - [[#plugins][Plugins]]
+
+* Description
+This module enables pixel-based smooth scrolling.
+
+** Module Flags
+This module provides no flags.
+
+** Plugins
++ [[https://github.com/io12/good-scroll.el][good-scroll]] (emacs-major-version < 29 and not emacs-mac)

--- a/modules/ui/pixel-scroll/config.el
+++ b/modules/ui/pixel-scroll/config.el
@@ -1,0 +1,9 @@
+;;; ui/pixel-scroll/config.el -*- lexical-binding: t; -*-
+
+(if (boundp 'mac-mouse-wheel-smooth-scroll)
+  (setq  mac-mouse-wheel-smooth-scroll t)
+  (if (> emacs-major-version 28)
+    (pixel-scroll-precision-mode)
+    (use-package! good-scroll
+      :config
+      (good-scroll-mode 1))))

--- a/modules/ui/pixel-scroll/packages.el
+++ b/modules/ui/pixel-scroll/packages.el
@@ -1,0 +1,5 @@
+;; -*- no-byte-compile: t; -*-
+;;; ui/pixel-scroll/packages.el
+
+(when (not (or (> emacs-major-version 28)  (boundp 'mac-mouse-wheel-smooth-scroll)))
+  (package! good-scroll :pin "8530d6697b15e0"))


### PR DESCRIPTION
I added a module under ui for providing smooth scrolling.
It fully takes into account `mac-mouse-wheel-smooth-scroll`, `pixel-scroll-precision-mode`, and provides the [good-scroll](https://github.com/io12/good-scroll.el) package if these options are not available (emacs 28 that is not a mac, or emacs 27 or less).

It activates the modes in this order of priority:
`mac-mouse-wheel-smooth-scroll` > `pixel-scroll-precision-mode` > `good-scroll`

Fixes https://github.com/doomemacs/doomemacs/issues/5871
Replaces https://github.com/doomemacs/doomemacs/pull/5873

https://user-images.githubusercontent.com/31109099/144915056-dc867d0e-2e7c-4d09-86a6-8fb1acb8327b.mp4

-----
- [x] I searched the issue tracker and this hasn't been PRed before.
- [x] My changes are not on [the do-not-PR list](https://doomemacs.org/d/do-not-pr) for this project.
- [x] My commits conform to [the git conventions](https://doomemacs.org/d/git-conventions).
- [x] My changes are visual; I've included before and after screenshots.
- [x] Any relevant issues or PRs have been linked to.